### PR TITLE
feat(composer, quickreply): add 'Post Anonymously' checkbox for replies

### DIFF
--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -65,6 +65,7 @@ define('quickreply', [
 				tid: ajaxify.data.tid,
 				handle: undefined,
 				content: replyMsg,
+				isAnonymous: components.get('topic/quickreply/container').find('input[name="isAnonymous"]').is(':checked'),
 			};
 			const replyLen = replyMsg.length;
 			if (replyLen < parseInt(config.minimumPostLength, 10)) {

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -13,6 +13,12 @@
 			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
 			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
 		</div>
+		<div class="form-check mb-2">
+			<input class="form-check-input" type="checkbox" name="isAnonymous" id="quickreply-anonymous">
+			<label class="form-check-label" for="quickreply-anonymous">
+				[[topic:anonymous-post]]
+			</label>
+		</div>
 		<div>
 			<div class="d-flex justify-content-end gap-2">
 				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>


### PR DESCRIPTION
# Summary
- Added checkbox to Quick Reply template (/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl) after textarea and before buttons
- Added checkbox to Full Composer template (/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl) alongside preview/help buttons
- Updated Quick Reply logic (/public/src/modules/quickreply.js) to include `isAnonymous` in replyData
- Updated Full Composer logic (/node_modules/nodebb-plugin-composer-default/static/lib/composer.js) to include `isAnonymous` in composerData

Backend support already exists, so these UI changes enable anonymous posting for inline and full replies.

# Testing for UI
**Test** was conducted through running nodebb, the checkbox is present, anonymous posting works both for quick reply and full reply. After the anonymous post was created, the user name is changed to Anonymous and the admin can view the real author. 