### PR TITLE
feat(posts): add endorse/unendorse backend API and socket support

### DIFF
--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -163,6 +163,18 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.endorse = async (req, res) => {
+	const data = await mock(req);
+	const result = await api.posts.endorse(req, data);
+	helpers.formatApiResponse(200, res, result);
+};
+
+Posts.unendorse = async (req, res) => {
+	const data = await mock(req);
+	const result = await api.posts.unendorse(req, data);
+	helpers.formatApiResponse(200, res, result);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -34,6 +34,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
+	setupApiRoute(router, 'post', '/:pid/endorse', middlewares, controllers.write.posts.endorse);
+	setupApiRoute(router, 'delete', '/:pid/endorse', middlewares, controllers.write.posts.unendorse);
+
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -110,4 +110,14 @@ SocketPosts.editQueuedContent = async function (socket, data) {
 	return await api.posts.editQueuedPost(socket, data);
 };
 
+SocketPosts.endorse = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'POST /api/v3/posts/:pid/endorse');
+	return await api.posts.endorse(socket, data);
+};
+
+SocketPosts.unendorse = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'DELETE /api/v3/posts/:pid/endorse');
+	return await api.posts.unendorse(socket, data);
+};
+
 require('../promisify')(SocketPosts);


### PR DESCRIPTION
[Issue #4](https://github.com/CMU-313/nodebb-fall-2025-strawberry/issues/4)
[Issue #5](https://github.com/CMU-313/nodebb-fall-2025-strawberry/issues/5)
[Isusue #7](https://github.com/CMU-313/nodebb-fall-2025-strawberry/issues/5)
Implements backend API endpoints and socket event handling for endorsing and unendorsing posts.
To support instructor/TA endorsement functionality in the forum — allowing staff to mark replies as correct and notify users in real time.
Adds new REST API routes, controller functions, and socket events to handle endorse/unendorse actions with proper permission checks, consistent API responses, and Redis-compatible data storage.

### **Changes Made**

**Added:**

postsAPI.endorse() and postsAPI.unendorse() functions (src/api/posts.js)

SocketPosts.endorse() and SocketPosts.unendorse() handlers (src/socket.io/posts.js)

Posts.endorse() and Posts.unendorse() controller methods (src/controllers/write/posts.js)

New routes for POST /:pid/endorse and DELETE /:pid/endorse (src/routes/write/posts.js)

**Updated:**

Privilege checks for admin/moderator roles

Error handling for duplicate or invalid endorsement actions

Real-time socket events (post_endorsed, post_unendorsed)

**Refactored:**

Response formatting in post write controllers for consistency

Redis compatibility by storing endorsement flags as 1/0 instead of boolean

### **Manual Testing:**

Verified that authorized users (admin/moderator) can endorse/unendorse posts through REST API.

Checked that socket clients receive post_endorsed and post_unendorsed events in real time.

Confirmed Redis storage correctness (1/0 values).

Ensured proper error messages for invalid or repeated actions.

### **Automated Testing:**

Unit tests added under test/endorsements.js

Manual test script validated in test_endorsements_manual.js