### PR TITLE
Add Ollama and Translator services to Docker Compose

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,6 +1,27 @@
 version: '3.8'
 
 services:
+  ollama:
+    image: ollama/ollama
+    container_name: ollama
+    volumes:
+      - ollama_data:/root/.ollama  # persists ollama data
+    restart: unless-stopped
+
+  translator:
+    build: ../translator-service
+    command: flask run --host=0.0.0.0
+    depends_on:
+      - ollama
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+      - FLASK_APP=app.py
+      - FLASK_ENV=development
+    ports:
+      - "5000:5000"
+    working_dir: /app
+    restart: unless-stopped
+
   nodebb:
     user: "0"
     build: .
@@ -23,6 +44,8 @@ services:
       - redis-data:/data
 
 volumes:
+  ollama_data:
+  
   redis-data:
     driver: local
     driver_opts:


### PR DESCRIPTION
✅ Summary of Changes

Added Ollama and translator containers to the same Docker Compose network as NodeBB.

Configured hostname-based communication so that:

NodeBB can reach the translator at http://translator:5000/

The translator can reach Ollama at its service hostname.

Updated environment variables and service dependencies for consistent startup order.

🔧 Alternative Setup

If preferred, you can switch to host network mode in Docker Compose.
In that configuration, all services share the host’s local network and can be accessed directly, e.g.:

http://127.0.0.1:5000/


See Docker’s documentation for details:
👉 https://docs.docker.com/reference/compose-file/services/#network_mode

🧩 Why This Matters

This setup allows NodeBB and your translation service to communicate directly within the same network, simplifying local development and deployment without extra configuration.